### PR TITLE
fixed a test for cast preconditions, fixed nullseeder, moved a common…

### DIFF
--- a/edu.cuny.hunter.optionalrefactoring.core/src/edu/cuny/hunter/optionalrefactoring/core/refactorings/NullPropagator.java
+++ b/edu.cuny.hunter.optionalrefactoring.core/src/edu/cuny/hunter/optionalrefactoring/core/refactorings/NullPropagator.java
@@ -99,18 +99,6 @@ class NullPropagator {
 		return decl.parameters().indexOf(svd);
 	}
 
-	private static int getParamNumber(List<ASTNode> arguments, Expression name) {
-		ASTNode curr = name;
-		while (curr != null) {
-			final int inx = arguments.indexOf(curr);
-			if (inx != -1)
-				return inx;
-			else
-				curr = curr.getParent();
-		}
-		return -1;
-	}
-
 	private final Set<IJavaElement> constFields;
 
 	private final Set<IJavaElement> found = new LinkedHashSet<>();
@@ -140,7 +128,7 @@ class NullPropagator {
 
 	private void findFormalsForVariable(ClassInstanceCreation ctorCall)
 			throws JavaModelException, CoreException {
-		final int paramNumber = getParamNumber(ctorCall.arguments(), this.name);
+		final int paramNumber = Util.getParamNumber(ctorCall.arguments(), this.name);
 		final IMethodBinding b = ctorCall.resolveConstructorBinding();
 		if (b == null) throw new HarvesterASTException("While trying to resolve the binding for a ClassInstanceCreation: ", ctorCall);
 	
@@ -192,7 +180,7 @@ class NullPropagator {
 			throw new HarvesterASTException(Messages.ASTNodeProcessor_SourceNotPresent,
 					ctorCall);
 		else
-			this.findFormalsForVariable(top, getParamNumber(ctorCall.arguments(), this.name));
+			this.findFormalsForVariable(top, Util.getParamNumber(ctorCall.arguments(), this.name));
 	}
 
 	private void findFormalsForVariable(IMethod correspondingMethod,
@@ -217,7 +205,7 @@ class NullPropagator {
 			throw new HarvesterASTException(Messages.ASTNodeProcessor_SourceNotPresent,
 					mi);
 		else
-			this.findFormalsForVariable(top, getParamNumber(mi.arguments(), this.name));
+			this.findFormalsForVariable(top, Util.getParamNumber(mi.arguments(), this.name));
 	}
 
 	private void findFormalsForVariable(SuperConstructorInvocation ctorCall)
@@ -232,7 +220,7 @@ class NullPropagator {
 			throw new HarvesterASTException(Messages.ASTNodeProcessor_SourceNotPresent,
 					ctorCall);
 		else
-			this.findFormalsForVariable(top, getParamNumber(ctorCall.arguments(), this.name));
+			this.findFormalsForVariable(top, Util.getParamNumber(ctorCall.arguments(), this.name));
 	}
 
 	private void findFormalsForVariable(SuperMethodInvocation smi)
@@ -248,7 +236,7 @@ class NullPropagator {
 			throw new HarvesterASTException(Messages.ASTNodeProcessor_SourceNotPresent,
 					smi);
 		else
-			this.findFormalsForVariable(top, getParamNumber(smi.arguments(),
+			this.findFormalsForVariable(top, Util.getParamNumber(smi.arguments(),
 					this.name));
 	}
 

--- a/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testCastExpression/in/A.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testCastExpression/in/A.java
@@ -2,21 +2,31 @@ package p;
 
 public class A {
 	
-	/*should seed d, should reject parseInt, b, m, should propagate only d*/
+	/*should seed a,l,q, should reject b,m,p*/
 	
 	class B { }
 	
-	Object a = (Object)new Object();
+	Object a = null;
 	
 	Object b = (Object)null;
 	
-	Object m(Object x) {
+	Object c = n((Object)null);
+	
+	Object d = o(null);
+	
+	Object l() {
+		return null;
+	}
+	
+	Object m() {
 		return (Object)null;
 	}
 	
-	Integer c = Integer.parseInt((String)null);
+	Object n(Object p) { 
+		return p;
+	}
 	
-	Object d = null;
-	
-	Object e = new Object();	
+	Object o(Object q) {	
+		return q;
+	}
 }

--- a/edu.cuny.hunter.optionalrefactoring.tests/test cases/edu/cuny/hunter/optionalrefactoring/ui/tests/ConvertNullToOptionalRefactoringTest.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/test cases/edu/cuny/hunter/optionalrefactoring/ui/tests/ConvertNullToOptionalRefactoringTest.java
@@ -269,9 +269,11 @@ public class ConvertNullToOptionalRefactoringTest extends RefactoringTest {
 	}
 	
 	public void testCastExpression() throws Exception {
-		this.preconditionsHelper(setOf("d"),
-				setOf("parseInt","b","m"),
-				setOf(setOf("d")));
+		this.preconditionsHelper(setOf("a","l","q"),
+				setOf("p","b","m"),
+				setOf(setOf("a"),
+						setOf("l"),
+						setOf("o","d","q")));
 	}
 	
 	public void testCastExpressionTransitiveVariable() throws Exception {


### PR DESCRIPTION
… method to Util

We have an unnecessary use of the `SearchEngine` in the `NullSeeder` class in trying to process formal parameters for `NullLiteral` arguments, I've removed that code, and also replaced a parameter position finding helper method I wrote (inefficiently) to do this with the static method that @khatchad wrote in the `NullPropagator` class ... and I shifted the location of that method to the `Util` class.

I also fixed incorrect semantics of the Precondition failure handling for a CastExpression instance... previously `Util.getEnclosingTypeDependentExpression` was finding the method name for a CastExpression argument, when it should be finding the formal parameter instead. It's fixed now.