### PR TITLE
Addressing Implicit Null transformation bugs

### DIFF
--- a/edu.cuny.hunter.optionalrefactoring.core/src/edu/cuny/hunter/optionalrefactoring/core/analysis/Entity.java
+++ b/edu.cuny.hunter.optionalrefactoring.core/src/edu/cuny/hunter/optionalrefactoring/core/analysis/Entity.java
@@ -359,6 +359,9 @@ public class Entity implements Iterable<IJavaElement> {
 						Expression wrapped = Entity.this.processRightHandSide(ast, action, expression);
 						if (wrapped != expression)
 							recovered.setInitializer(wrapped);
+					} else {	// if it is an uninitialized field decl
+						if (copy.getNodeType() == ASTNode.FIELD_DECLARATION)
+							recovered.setInitializer(Entity.this.emptyOptional(ast));
 					}
 				}
 				return super.visit(recovered);

--- a/edu.cuny.hunter.optionalrefactoring.core/src/edu/cuny/hunter/optionalrefactoring/core/refactorings/NullSeeder.java
+++ b/edu.cuny.hunter.optionalrefactoring.core/src/edu/cuny/hunter/optionalrefactoring/core/refactorings/NullSeeder.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.dom.ConstructorInvocation;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
@@ -33,6 +34,7 @@ import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NullLiteral;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.SuperFieldAccess;
@@ -465,14 +467,43 @@ class NullSeeder {
 						IVariableBinding binding = Util.resolveBinding(node);
 						IJavaElement element = Util.resolveElement(node);
 						if (element instanceof IField)
-							if (NullSeeder.this.settings.seedsImplicit())
-								if (node.getInitializer() == null)
+							if (NullSeeder.this.settings.seedsImplicit()) {
+								List<Boolean> fici = new LinkedList<>(); 
+								NullSeeder.this.refactoringRootNode.accept(new ASTVisitor() {
+									@Override
+									public boolean visit(MethodDeclaration node) {
+										if (node.isConstructor()) {
+											Set<Boolean> initialized = new LinkedHashSet<>();
+											node.accept(new ASTVisitor() {
+												@Override
+												public boolean visit(Assignment node) {
+													Expression expr = node.getLeftHandSide();
+													IVariableBinding targetField = null;
+													switch (expr.getNodeType()) {
+													case ASTNode.FIELD_ACCESS: targetField = ((FieldAccess)expr).resolveFieldBinding();
+													break;
+													case ASTNode.SIMPLE_NAME:
+													case ASTNode.QUALIFIED_NAME: targetField = (IVariableBinding) ((Name)expr).resolveBinding();
+													}
+													if (binding.isEqualTo(targetField)) initialized.add(Boolean.TRUE);
+													return super.visit(node);
+												}
+											});
+											if (initialized.contains(Boolean.TRUE)) fici.add(Boolean.TRUE);
+											else fici.add(Boolean.FALSE);
+										}
+										return super.visit(node);
+									}
+								});
+								boolean fieldIsConstructorInitialized = fici.stream().reduce(Boolean.TRUE, Boolean::logicalAnd);
+								if (node.getInitializer() == null && !fieldIsConstructorInitialized)
 									/*
 									 * this element gets added to the Map candidates with boolean true indicating an
 									 * implicit null also, if the type of the declaration is primitive, we ignore it
 									 */
 									if (!binding.getVariableDeclaration().getType().isPrimitive())
 										NullSeeder.this.candidates.add(element);
+							}
 					} catch (HarvesterException e) {
 						Logger.getAnonymousLogger()
 								.warning(Messages.Harvester_NullLiteralFailed + "\n" + e.getMessage());

--- a/edu.cuny.hunter.optionalrefactoring.core/src/edu/cuny/hunter/optionalrefactoring/core/refactorings/NullSeeder.java
+++ b/edu.cuny.hunter.optionalrefactoring.core/src/edu/cuny/hunter/optionalrefactoring/core/refactorings/NullSeeder.java
@@ -495,7 +495,7 @@ class NullSeeder {
 										return super.visit(node);
 									}
 								});
-								boolean fieldIsConstructorInitialized = fici.stream().reduce(Boolean.TRUE, Boolean::logicalAnd);
+								boolean fieldIsConstructorInitialized = fici.isEmpty() ? false : fici.stream().reduce(Boolean.TRUE, Boolean::logicalAnd);
 								if (node.getInitializer() == null && !fieldIsConstructorInitialized)
 									/*
 									 * this element gets added to the Map candidates with boolean true indicating an

--- a/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldConstructorInit/in/A.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldConstructorInit/in/A.java
@@ -1,0 +1,13 @@
+package p;
+
+public class A {
+	/** 
+	 * With implicit nulls option by default
+	 */
+	Object a;
+	
+	public A() {
+		a = new Object();
+	}
+	
+}

--- a/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldConstructorInit/out/A.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldConstructorInit/out/A.java
@@ -1,0 +1,13 @@
+package p;
+
+public class A {
+	/** 
+	 * With implicit nulls option by default
+	 */
+	Object a;
+	
+	public A() {
+		a = new Object();
+	}
+	
+}

--- a/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldNoConstructorInit/in/A.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldNoConstructorInit/in/A.java
@@ -1,0 +1,9 @@
+package p;
+
+public class A {
+	/** 
+	 * With implicit nulls option by default
+	 */
+	Object a;
+
+}

--- a/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldNoConstructorInit/out/A.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldNoConstructorInit/out/A.java
@@ -3,9 +3,9 @@ package p;
 import java.util.Optional;
 
 public class A {
-	/** 
+	/**
 	 * With implicit nulls option by default
 	 */
 	Optional<Object> a = Optional.empty();
-	
+
 }

--- a/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldNoConstructorInit/out/A.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldNoConstructorInit/out/A.java
@@ -1,0 +1,11 @@
+package p;
+
+import java.util.Optional;
+
+public class A {
+	/** 
+	 * With implicit nulls option by default
+	 */
+	Optional<Object> a = Optional.empty();
+	
+}

--- a/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldSomeConstructorInit/in/A.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldSomeConstructorInit/in/A.java
@@ -1,0 +1,14 @@
+package p;
+
+public class A {
+	/** 
+	 * With implicit nulls option by default
+	 */
+	Object a;
+	
+	public A() {
+		this.a = new Object();
+	}
+	
+	public A(Object o) { }
+}

--- a/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldSomeConstructorInit/out/A.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldSomeConstructorInit/out/A.java
@@ -3,7 +3,7 @@ package p;
 import java.util.Optional;
 
 public class A {
-	/** 
+	/**
 	 * With implicit nulls option by default
 	 */
 	Optional<Object> a = Optional.empty();

--- a/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldSomeConstructorInit/out/A.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/resources/ConvertNullToOptional/testImplicitlyNullFieldSomeConstructorInit/out/A.java
@@ -1,0 +1,16 @@
+package p;
+
+import java.util.Optional;
+
+public class A {
+	/** 
+	 * With implicit nulls option by default
+	 */
+	Optional<Object> a = Optional.empty();
+	
+	public A() {
+		this.a = Optional.of(new Object());
+	}
+	
+	public A(Object o) { }
+}

--- a/edu.cuny.hunter.optionalrefactoring.tests/test cases/edu/cuny/hunter/optionalrefactoring/ui/tests/ConvertNullToOptionalRefactoringTest.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/test cases/edu/cuny/hunter/optionalrefactoring/ui/tests/ConvertNullToOptionalRefactoringTest.java
@@ -205,7 +205,19 @@ public class ConvertNullToOptionalRefactoringTest extends RefactoringTest {
 		Path absolutePath = this.getAbsolutionPath(fileName);
 		Files.write(absolutePath, contents.getBytes());
 	}
+	
+	public void testImplicitlyNullFieldConstructorInit() throws Exception {
+		this.transformationHelper(null);
+	}
 
+	public void testImplicitlyNullFieldNoConstructorInit() throws Exception {
+		this.transformationHelper(null);
+	}
+
+	public void testImplicitlyNullFieldSomeConstructorInit() throws Exception {
+		this.transformationHelper(null);
+	}
+	
 	public void testAnonymousClassDeclaration() throws Exception {
 		this.propagationHelper(setOf(setOf("o")), setOf(), null, new RefactoringStatus());
 	}

--- a/edu.cuny.hunter.optionalrefactoring.tests/test cases/edu/cuny/hunter/optionalrefactoring/ui/tests/ConvertNullToOptionalRefactoringTest.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/test cases/edu/cuny/hunter/optionalrefactoring/ui/tests/ConvertNullToOptionalRefactoringTest.java
@@ -207,15 +207,15 @@ public class ConvertNullToOptionalRefactoringTest extends RefactoringTest {
 	}
 	
 	public void testImplicitlyNullFieldConstructorInit() throws Exception {
-		this.transformationHelper(null);
+		this.transformationHelper(null, RefactoringStatus.createErrorStatus("No nulls to refactor."));
 	}
 
 	public void testImplicitlyNullFieldNoConstructorInit() throws Exception {
-		this.transformationHelper(null);
+		this.transformationHelper(null, new RefactoringStatus());
 	}
 
 	public void testImplicitlyNullFieldSomeConstructorInit() throws Exception {
-		this.transformationHelper(null);
+		this.transformationHelper(null, new RefactoringStatus());
 	}
 	
 	public void testAnonymousClassDeclaration() throws Exception {
@@ -381,26 +381,26 @@ public class ConvertNullToOptionalRefactoringTest extends RefactoringTest {
 	}
 
 	public void testTransformationFieldAccessAssignment() throws Exception {
-		this.transformationHelper(null);
+		this.transformationHelper(null, new RefactoringStatus());
 	}
 
 	public void testTransformationFieldDeclLocal() throws Exception {
-		this.transformationHelper(null);
+		this.transformationHelper(null, new RefactoringStatus());
 	}
 
 	public void testTransformationLocalVarAssignment() throws Exception {
-		this.transformationHelper(null);
+		this.transformationHelper(null, new RefactoringStatus());
 	}
 
 	public void testTransformationLocalVarDeclLocal() throws Exception {
-		this.transformationHelper(null);
+		this.transformationHelper(null, new RefactoringStatus());
 	}
 
 	public void testTransformationMethDeclLocal() throws Exception {
-		this.transformationHelper(null);
+		this.transformationHelper(null, new RefactoringStatus());
 	}
 
-	private void transformationHelper(Choices turnOff) throws Exception {
+	private void transformationHelper(Choices turnOff, RefactoringStatus expectedStatus) throws Exception {
 		ICompilationUnit icu = this.createCUfromTestFile(this.getPackageP(), "A");
 
 		ProcessorBasedRefactoring refactoring = (ProcessorBasedRefactoring) this.getRefactoring(icu);
@@ -413,7 +413,7 @@ public class ConvertNullToOptionalRefactoringTest extends RefactoringTest {
 		RefactoringStatus finalStatus = refactoring.checkFinalConditions(new NullProgressMonitor());
 		this.getLogger().info("Final status: " + finalStatus);
 
-		assertTrue("Precondition was supposed to pass.", finalStatus.isOK());
+		assertTrue("Precondition checking returned the expected RefactoringStatus: "+expectedStatus+".", finalStatus.getSeverity() == expectedStatus.getSeverity());
 		this.performChange(refactoring, false);
 
 		String outputTestFileName = this.getOutputTestFileName("A");


### PR DESCRIPTION
Ref #93 

`NullSeeder` upon finding FieldDeclarations that are uninitialized now appropriately traverses the class searching for constructors and checking if each of them initialize the field. If this is true, the field will not be seeded.