### PR TITLE
Fix the issue that can't run test suite inside of Eclipse

### DIFF
--- a/edu.cuny.hunter.optionalrefactoring.tests/test cases/edu/cuny/hunter/optionalrefactoring/ui/tests/ConvertNullToOptionalRefactoringTest.java
+++ b/edu.cuny.hunter.optionalrefactoring.tests/test cases/edu/cuny/hunter/optionalrefactoring/ui/tests/ConvertNullToOptionalRefactoringTest.java
@@ -5,6 +5,7 @@ package edu.cuny.hunter.optionalrefactoring.ui.tests;
 
 import static edu.cuny.hunter.optionalrefactoring.core.utils.Util.setOf;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -68,6 +69,27 @@ public class ConvertNullToOptionalRefactoringTest extends RefactoringTest {
 
 	public ConvertNullToOptionalRefactoringTest(String name) {
 		super(name);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+
+		if (this.getPackageP().exists()) {
+			tryDeletingJavaFiles(this.getPackageP());
+		}
+
+		super.tearDown();
+	}
+
+	private static void tryDeletingJavaFiles(IPackageFragment pack) throws JavaModelException {
+		File sourceFile = pack.getResource().getLocation().append("A.java").toFile();
+
+		// delete the file.
+		try {
+			Files.delete(sourceFile.toPath());
+		} catch (IOException e) {
+			throw new IllegalArgumentException("Source file does not exist.", e);
+		}
 	}
 
 	/*


### PR DESCRIPTION
Related to #112. The problem is that the value of "this.getPackage()" is not reset for each test because the directory of `p` is not cleared. 